### PR TITLE
feat: support env variables from file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/moby/moby v20.10.5+incompatible // indirect
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
+	github.com/stretchr/testify v1.7.0
 	github.com/tedsuo/rata v1.0.0 // indirect
 	github.com/vito/go-interact v1.0.0 // indirect
 	google.golang.org/protobuf v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -686,8 +686,6 @@ github.com/hashicorp/waypoint v0.3.1 h1:VOt1oqjzdBMhBlyFY8c4WTITlZgos+muR33d1n1s
 github.com/hashicorp/waypoint v0.3.1/go.mod h1:Or41JMptSvA9jXig8u7v5Sit8NyRZBtU5pqGMotLEAk=
 github.com/hashicorp/waypoint-hzn v0.0.0-20201008221232-97cd4d9120b9/go.mod h1:ObgQSWSX9rsNofh16kctm6XxLW2QW1Ay6/9ris6T6DU=
 github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210319163606-c48e1a6cba30/go.mod h1:Lwc83y1fKC2ktVgbU6jkKbgFNJuR3N+gSWpVHQ+0KSI=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210405143251-32d519ff58f3 h1:BQr3p3UxyR6FtI9rox7NJTVWpy2w3sAgT6ksX2pnFIc=
-github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210405143251-32d519ff58f3/go.mod h1:Lwc83y1fKC2ktVgbU6jkKbgFNJuR3N+gSWpVHQ+0KSI=
 github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210420153757-b55c787a65ff h1:lSnniYU+3xbOcFyeYydSEdHEa9rOqNX0oAIbK2p0Ndg=
 github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210420153757-b55c787a65ff/go.mod h1:Lwc83y1fKC2ktVgbU6jkKbgFNJuR3N+gSWpVHQ+0KSI=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/platform/deploy.go
+++ b/platform/deploy.go
@@ -21,12 +21,12 @@ type PlatformConfig struct {
 }
 
 type Config struct {
-	Organisation      string             `hcl:"organisation"`
-	Space             string             `hcl:"space"`
-	DockerEncodedAuth string             `hcl:"docker_encoded_auth,optional"`
-	Domain            string             `hcl:"domain"`
-	Env               *map[string]string `hcl:"env"`
-	EnvFromFile       *string            `hcl:"envFromFile"`
+	Organisation      string            `hcl:"organisation"`
+	Space             string            `hcl:"space"`
+	DockerEncodedAuth string            `hcl:"docker_encoded_auth,optional"`
+	Domain            string            `hcl:"domain"`
+	Env               map[string]string `hcl:"env,optional"`
+	EnvFromFile       string            `hcl:"envFromFile,optional"`
 }
 
 type Platform struct {
@@ -225,20 +225,20 @@ func (b *Platform) deploy(ctx context.Context, ui terminal.UI, img *docker.Image
 	}
 	step.Done()
 
-	if b.config.Env != nil || b.config.EnvFromFile != nil {
+	if len(b.config.Env) != 0 || b.config.EnvFromFile != "" {
 		step = sg.Add("Assigning environment variables")
 		envVars := ccv3.EnvironmentVariables{}
 
 		// Precedence: envFromFile, env
-		if b.config.EnvFromFile != nil {
-			envContent := utils.ParseEnv(*b.config.EnvFromFile)
+		if b.config.EnvFromFile != "" {
+			envContent := utils.ParseEnv(b.config.EnvFromFile)
 			for k, v := range envContent {
 				addFilteredEnvVar(envVars, k, v)
 			}
 		}
 
-		if b.config.Env != nil {
-			for k, v := range *b.config.Env {
+		if len(b.config.Env) != 0 {
+			for k, v := range b.config.Env {
 				addFilteredEnvVar(envVars, k, v)
 			}
 		}

--- a/utils/env.go
+++ b/utils/env.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+func ParseEnv(s string) map[string]string {
+	env := map[string]string{}
+	envRegex := regexp.MustCompile("^([^#].*?)=(.*)$")
+	for _, line := range strings.Split(s, "\n") {
+		if !envRegex.MatchString(line) {
+			continue
+		}
+
+		matches := envRegex.FindStringSubmatch(line)
+		if len(matches) != 3 {
+			continue
+		}
+		env[matches[1]] = matches[2]
+
+	}
+	return env
+}

--- a/utils/env_test.go
+++ b/utils/env_test.go
@@ -1,0 +1,14 @@
+package utils_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/swisscom/waypoint-plugin-cloudfoundry/utils"
+	"testing"
+)
+
+func TestParseEnv(t *testing.T){
+	envs := utils.ParseEnv("HELLO=world\n#comment\n#COMMENT=ok\nKUBECONFIG=none")
+	assert.Equal(t, "world", envs["HELLO"])
+	assert.Equal(t, "none", envs["KUBECONFIG"])
+	assert.Len(t, envs, 2)
+}


### PR DESCRIPTION
This commit allows to specify an envFromFile entry in the `deploy`
stanza that will allow to load some additional environment variables
from the filesystem.

Usage:
```hcl
envFromFile = file(abspath("./.env"))
```

Note that, despite the name, the envFromFile content is actually
the content of ./.env in the example above.