### PR TITLE
feat: add support for custom quota

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/cppforlife/go-patch v0.2.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/hashicorp/go-hclog v0.14.1 // indirect
 	github.com/hashicorp/waypoint v0.3.1
 	github.com/hashicorp/waypoint-plugin-sdk v0.0.0-20210420153757-b55c787a65ff
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
@@ -30,6 +31,7 @@ require (
 	github.com/tedsuo/rata v1.0.0 // indirect
 	github.com/vito/go-interact v1.0.0 // indirect
 	google.golang.org/protobuf v1.26.0
+	k8s.io/apimachinery v0.19.4 // indirect
 )
 
 // replace github.com/hashicorp/waypoint-plugin-sdk => ../../waypoint-plugin-sdk


### PR DESCRIPTION
This commit adds support for the `quota` block in the `deploy` stanza.
With this new change it is now possible to specify the following:
- memory
- disk
- instances

```hcl
quota {
    memory = "2Gi"
    disk = "5Gi"
    instances = 5
}
```

The format for specifying memory and disk is identical to the one used
in Kubernetes.