### PR TITLE
Switch to CF_DOCKER_PASSWORD

### DIFF
--- a/platform/errors.go
+++ b/platform/errors.go
@@ -1,0 +1,4 @@
+package platform
+
+const errDockerPasswordEmpty = `docker password is empty: please specify a password using the ` +
+	`CF_DOCKER_PASSWORD environment variable`


### PR DESCRIPTION
This PR changes the way we authenticate with Docker by using the same environment variable `CF_DOCKER_PASSWORD` as the CF CLI is using. This will allow us to easily migrate away from `cf` and more importantly avoids the creation of a file laying around in the repo with the Docker credentials.