### PR TITLE
New SDK

### DIFF
--- a/platform/deploy.go
+++ b/platform/deploy.go
@@ -437,4 +437,4 @@ func addFilteredEnvVar(envVars ccv3.EnvironmentVariables, k string, v string) {
 	}
 }
 
-var _ component.Deployment = (*Deployment)(nil)
+var _ component.DeploymentWithUrl = (*Deployment)(nil)


### PR DESCRIPTION
Depends on #6 

This PR adapts the changes of https://github.com/hashicorp/waypoint-plugin-sdk/pull/27 by defining using `component.DeploymentWithUrl` instead of `component.Deployment`. 