### PR TITLE
fix: service bindings

### DIFF
--- a/platform/cloudfoundry_test.go
+++ b/platform/cloudfoundry_test.go
@@ -1,0 +1,24 @@
+package platform_test
+
+import (
+	"github.com/swisscom/waypoint-plugin-cloudfoundry/platform"
+	"testing"
+)
+
+func TestGetServiceBindRepository(t *testing.T) {
+	sbr, err := platform.GetServiceBindRepository()
+	if err != nil {
+		t.Fatalf("unable to get Service Bind repository")
+	}
+
+	var params map[string]interface{}
+	err = sbr.Create(
+		"cf1a8bf1-7948-4765-88a3-e278b00d8358",
+		"e2d4d416-a6a0-4d73-b6fc-b5dff6c52f63",
+		params,
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/platform/deploy.go
+++ b/platform/deploy.go
@@ -612,11 +612,16 @@ func (p *Platform) bindServices(state *DeploymentState) error {
 				step.Abort()
 				return fmt.Errorf("found %d service instances with the name \"%s\"",
 					len(serviceInstances),
-					serviceName,
-				)
+					serviceName)
 			}
 
 			// bind service
+			p.log.Debug("create service binding",
+				"serviceInstance", serviceInstances[0],
+				"app", state.app,
+				"serviceInstanceGUID", serviceInstances[0].GUID,
+				"appGUID", state.app.GUID,
+			)
 			err = sbRepo.Create(serviceInstances[0].GUID, state.app.GUID, map[string]interface{}{})
 			if err != nil {
 				step.Abort()


### PR DESCRIPTION
The previous implementation of service bindings was panicing
because we didn't properly instantiated the
CloudControllerServiceBindingRepository, and i18n.T was nil.

With the current implementation, there is no need to instantiate
the command that way. We now solely rely on the `commandregistry`
package and the `api` one as the CLI does.

In addition to this, a smoke test was added
(TestGetServiceBindRepository). This lets us test (with a CF
connection) if the service binding works as expected.
Note: this test assumes that the service is not bound yet,
therefore an error when the service is already bound is
normal.